### PR TITLE
Fix asset upload for releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,11 @@ jobs:
         version_format: "${major}.${minor}.${patch}-${increment}"
         change_path: "."
     - name: Build with Ant
-      run: ant -noinput -buildfile build.xml
+      run: ant -noinput -buildfile build.xml -Dversion=v${{ steps.ver.outputs.version }}
     - name: Create release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: ./out/BearInMind.jar
+        artifacts: ./out/BearInMind-*.jar
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: v${{ steps.ver.outputs.version }}
         commit: 'main'

--- a/build.xml
+++ b/build.xml
@@ -16,6 +16,7 @@
 
   <target name="init">
     <tstamp />
+    <property name="version" value="USERBUILD-${DSTAMP}" />
     <mkdir dir="${dest}/main" />
     <mkdir dir="${dest}/test" />
     <mkdir dir="${out}/test-report" />
@@ -40,7 +41,7 @@
   </target>
 
   <target name="build" depends="compile" description="build jar file">
-    <jar jarfile="${out}/BearInMind-${DSTAMP}.jar">
+    <jar jarfile="${out}/BearInMind-${version}.jar">
       <fileset dir="${dest}/main"/>
       <fileset dir="${res}"/>
       <manifest>


### PR DESCRIPTION
Added version number to asset name set as Ant property.
Defaults to the current date as before in case of non-CI/CD build.